### PR TITLE
Protected Embeds: Add CLI command to render all `protected-iframe` shortcodes

### DIFF
--- a/class-wpcom-compat-command.php
+++ b/class-wpcom-compat-command.php
@@ -164,7 +164,7 @@ class WPCOM_Compat_Command extends WPCOM_VIP_CLI_Command {
 
 			$affected++;
 
-			if ( $affected % 100 == 0 ) {
+			if ( 0 === $affected % 100 ) {
 				WP_CLI::line( '100 posts updated. Waiting 1 second...' );
 				$this->stop_the_insanity();
 				sleep( 1 );

--- a/class-wpcom-compat-command.php
+++ b/class-wpcom-compat-command.php
@@ -139,7 +139,10 @@ class WPCOM_Compat_Command extends WPCOM_VIP_CLI_Command {
 
 		// Add custom protected-iframe handler
 		add_shortcode( 'protected-iframe', function ( $attrs ) use ( $protected_embeds ) {
-			return $protected_embeds[ $attrs['id'] ]['html'];
+			if ( isset( $attrs['id'] ) && isset( $protected_embeds[ $attrs['id'] ] ) ) {
+				return $protected_embeds[ $attrs['id'] ]['html'];
+			}
+			return '<!-- Invalid protected-iframe shortcode replacement -->';
 		} );
 
 		// Query for posts with the protected-iframe shortcode

--- a/class-wpcom-compat-command.php
+++ b/class-wpcom-compat-command.php
@@ -78,18 +78,18 @@ class WPCOM_Compat_Command extends WPCOM_VIP_CLI_Command {
 	}
 
 	/**
-	 * Parses existent protected embeds from WordPress.com
+	 * Replace existent protected embeds from WordPress.com
 	 *
-	 * This will replace all the protected-iframe shortcodes with the correct rendered embed
+	 * This will replace all the protected-iframe shortcodes with the correct rendered embed.
 	 *
 	 * # OPTIONS
 	 *
 	 * <file>
 	 *  : The CSV file with protected embeds
 	 *
-	 * @subcommand parse-protected-embeds
+	 * @subcommand replace-protected-embeds
 	 */
-	function parse_protected_embeds( $args ) {
+	function replace_protected_embeds( $args ) {
 		$file = $args[0];
 
 		if ( ! file_exists( $file ) ) {

--- a/class-wpcom-compat-command.php
+++ b/class-wpcom-compat-command.php
@@ -134,20 +134,20 @@ class WPCOM_Compat_Command extends WPCOM_VIP_CLI_Command {
 		} );
 
 		// Query for posts with the protected-iframe shortcode
-		WP_CLI::line( "Looking for posts with protected-iframe shortcode." );
+		WP_CLI::line( 'Looking for posts with protected-iframe shortcode.' );
 
 		global $wpdb;
 		$query = $wpdb->get_results("SELECT ID, post_content FROM $wpdb->posts WHERE `post_content` LIKE '%protected-iframe%'" );
 
 		$affected = 0;
 
-		WP_CLI::line( sprintf( "Found %d posts.", count( $query ) ) );
+		WP_CLI::line( sprintf( 'Found %d posts.', count( $query ) ) );
 		sleep( 3 );
 
 		foreach ( $query as $post ) {
 
 			// Post does not have a protected-iframe, skip it
-			if ( strpos( $post->post_content, "protected-iframe" ) === false ) {
+			if ( strpos( $post->post_content, 'protected-iframe' ) === false ) {
 				continue;
 			}
 
@@ -159,21 +159,21 @@ class WPCOM_Compat_Command extends WPCOM_VIP_CLI_Command {
 			$update = $wpdb->update( $wpdb->posts, array( 'post_content' => stripslashes( $parsed_content ) ), array( 'ID' => $post->ID ) );
 
 			if ( ! $update ) {
-				WP_CLI::error( sprintf( "Error updating %d. Aborting. Updated %d posts so far.", $post->ID, $affected ) );
+				WP_CLI::error( sprintf( 'Error updating %d. Aborting. Updated %d posts so far.', $post->ID, $affected ) );
 				return;
 			}
 
 			$affected++;
 
 			if ( $affected % 100 == 0 ) {
-				WP_CLI::line( "100 posts updated. Waiting 1 second..." );
+				WP_CLI::line( '100 posts updated. Waiting 1 second...' );
 				$this->stop_the_insanity();
 				sleep( 1 );
 			}
 
 		}
 
-		WP_CLI::success( sprintf( "Done! %d posts updated.", $affected ) );
+		WP_CLI::success( sprintf( 'Done! %d posts updated.', $affected ) );
 	}
 }
 

--- a/class-wpcom-compat-command.php
+++ b/class-wpcom-compat-command.php
@@ -151,10 +151,10 @@ class WPCOM_Compat_Command extends WPCOM_VIP_CLI_Command {
 		$affected = 0;
 
 		WP_CLI::line( sprintf( 'Found %d posts.', count( $query ) ) );
-		
+
 		foreach ( $query as $post ) {
 			// Post does not have a protected-iframe, skip it
-			if ( strpos( $post->post_content, '[protected-iframe' ) === false ) {
+			if ( false === strpos( $post->post_content, '[protected-iframe' ) ) {
 				continue;
 			}
 

--- a/class-wpcom-compat-command.php
+++ b/class-wpcom-compat-command.php
@@ -151,8 +151,7 @@ class WPCOM_Compat_Command extends WPCOM_VIP_CLI_Command {
 		$affected = 0;
 
 		WP_CLI::line( sprintf( 'Found %d posts.', count( $query ) ) );
-		sleep( 3 );
-
+		
 		foreach ( $query as $post ) {
 			// Post does not have a protected-iframe, skip it
 			if ( strpos( $post->post_content, '[protected-iframe' ) === false ) {

--- a/class-wpcom-compat-command.php
+++ b/class-wpcom-compat-command.php
@@ -146,7 +146,7 @@ class WPCOM_Compat_Command extends WPCOM_VIP_CLI_Command {
 		WP_CLI::line( 'Looking for posts with protected-iframe shortcode.' );
 
 		global $wpdb;
-		$query = $wpdb->get_results( "SELECT ID, post_content FROM $wpdb->posts WHERE `post_content` LIKE '%protected-iframe%'" );
+		$query = $wpdb->get_results( "SELECT ID, post_content FROM $wpdb->posts WHERE `post_content` LIKE '%[protected-iframe%'" );
 
 		$affected = 0;
 
@@ -155,7 +155,7 @@ class WPCOM_Compat_Command extends WPCOM_VIP_CLI_Command {
 
 		foreach ( $query as $post ) {
 			// Post does not have a protected-iframe, skip it
-			if ( strpos( $post->post_content, 'protected-iframe' ) === false ) {
+			if ( strpos( $post->post_content, '[protected-iframe' ) === false ) {
 				continue;
 			}
 

--- a/class-wpcom-compat-command.php
+++ b/class-wpcom-compat-command.php
@@ -181,6 +181,9 @@ class WPCOM_Compat_Command extends WPCOM_VIP_CLI_Command {
 				sleep( 1 );
 			}
 		}
+		
+		WP_CLI::line('Clearing cache...');
+		wp_cache_flush();
 
 		WP_CLI::success( sprintf( 'Done! %d posts updated.', $affected ) );
 	}

--- a/class-wpcom-compat-command.php
+++ b/class-wpcom-compat-command.php
@@ -81,11 +81,20 @@ class WPCOM_Compat_Command extends WPCOM_VIP_CLI_Command {
 	 * Replace existent protected embeds from WordPress.com
 	 *
 	 * This will replace all the protected-iframe shortcodes with the correct rendered embed.
+	 * 
+	 * To generate the CSV file with all the protected embeds, the following command can be used:
+	 * 
+	 * 		wp vip export-protected-embeds --url= > site-protected-embeds.csv
 	 *
 	 * # OPTIONS
 	 *
 	 * <file>
 	 *  : The CSV file with protected embeds
+	 *
+	 * ## EXAMPLES
+	 *
+	 *     # Replaces all the protected-iframe shortcodes with the respective HTML
+	 *     $ wp wpcom-compat import-user-meta replace-protected-embeds site-protected-embeds.csv
 	 *
 	 * @subcommand replace-protected-embeds
 	 */

--- a/class-wpcom-compat-command.php
+++ b/class-wpcom-compat-command.php
@@ -103,12 +103,12 @@ class WPCOM_Compat_Command extends WPCOM_VIP_CLI_Command {
 
 		$header = fgetcsv( $fd );
 		if ( ! is_array( $header ) || count( $header ) !== 6 ||
-		     ! in_array( 'id', $header, true ) ||
-		     ! in_array( 'embed_id', $header, true ) ||
-		     ! in_array( 'src', $header, true ) ||
-		     ! in_array( 'embed_group_id', $header, true ) ||
-		     ! in_array( 'html', $header, true ) ||
-		     ! in_array( 'time_added', $header, true ) ) {
+			 ! in_array( 'id', $header, true ) ||
+			 ! in_array( 'embed_id', $header, true ) ||
+			 ! in_array( 'src', $header, true ) ||
+			 ! in_array( 'embed_group_id', $header, true ) ||
+			 ! in_array( 'html', $header, true ) ||
+			 ! in_array( 'time_added', $header, true ) ) {
 			WP_CLI::error( 'Invalid CSV, missing required fields' );
 		}
 

--- a/class-wpcom-compat-command.php
+++ b/class-wpcom-compat-command.php
@@ -166,7 +166,7 @@ class WPCOM_Compat_Command extends WPCOM_VIP_CLI_Command {
 			WP_CLI::line( " * Found {$post->ID}. Updating post content..." );
 
 			// Update the post using $wpdb, to bypass any filters/options being called on `wp_insert_post`.
-			$update = $wpdb->update( $wpdb->posts, array( 'post_content' => stripslashes( $parsed_content ) ), array( 'ID' => $post->ID ) );
+			$update = $wpdb->update( $wpdb->posts, array( 'post_content' => $parsed_content ), array( 'ID' => $post->ID ) );
 
 			if ( ! $update ) {
 				WP_CLI::error( sprintf( 'Error updating %d. Aborting. Updated %d posts so far.', $post->ID, $affected ) );

--- a/class-wpcom-compat-command.php
+++ b/class-wpcom-compat-command.php
@@ -76,6 +76,105 @@ class WPCOM_Compat_Command extends WPCOM_VIP_CLI_Command {
 			WP_CLI::line( sprintf( 'Failed to insert %d embeds', $errors ) );
 		}
 	}
+
+	/**
+	 * Parses existent protected embeds from WordPress.com
+	 *
+	 * This will replace all the protected-iframe shortcodes with the correct rendered embed
+	 *
+	 * # OPTIONS
+	 *
+	 * <file>
+	 *  : The CSV file with protected embeds
+	 *
+	 * @subcommand parse-protected-embeds
+	 */
+	function parse_protected_embeds( $args ) {
+		$file = $args[0];
+
+		if ( ! file_exists( $file ) ) {
+			WP_CLI::error( 'Specified file does not exist' );
+		}
+
+		$fd = fopen( $file, 'r' );
+		if ( ! $fd ) {
+			WP_CLI::error( sprintf( 'Could not open file: %s', $file ) );
+		}
+
+		$header = fgetcsv( $fd );
+		if ( ! is_array( $header ) || count( $header ) !== 6 ||
+		     ! in_array( 'id', $header, true ) ||
+		     ! in_array( 'embed_id', $header, true ) ||
+		     ! in_array( 'src', $header, true ) ||
+		     ! in_array( 'embed_group_id', $header, true ) ||
+		     ! in_array( 'html', $header, true ) ||
+		     ! in_array( 'time_added', $header, true ) ) {
+			WP_CLI::error( 'Invalid CSV, missing required fields' );
+		}
+
+		$protected_embeds = array();
+
+		// Main CSV loop
+		while ( $row = fgetcsv( $fd ) ) {
+			$data = array_combine( $header, $row );
+			if ( empty( $data ) || ! $data['id'] ) {
+				continue;
+			}
+
+			$protected_embeds[ $data['embed_id'] ] = $data;
+		}
+
+		// Remove all shortcodes and add the protected-iframes handler
+		global $shortcode_tags;
+		$shortcode_tags = array();
+
+		// Add custom protected-iframe handler
+		add_shortcode( 'protected-iframe', function( $attrs ) use( $protected_embeds ) {
+			return $protected_embeds[ $attrs['id'] ]['html'];
+		} );
+
+		// Query for posts with the protected-iframe shortcode
+		WP_CLI::line( "Looking for posts with protected-iframe shortcode." );
+
+		global $wpdb;
+		$query = $wpdb->get_results("SELECT ID, post_content FROM $wpdb->posts WHERE `post_content` LIKE '%protected-iframe%'" );
+
+		$affected = 0;
+
+		WP_CLI::line( sprintf( "Found %d posts.", count( $query ) ) );
+		sleep( 3 );
+
+		foreach ( $query as $post ) {
+
+			// Post does not have a protected-iframe, skip it
+			if ( strpos( $post->post_content, "protected-iframe" ) === false ) {
+				continue;
+			}
+
+			$parsed_content = do_shortcode( $post->post_content );
+
+			WP_CLI::line( " * Found {$post->ID}. Updating post content..." );
+
+			// Update the post using $wpdb, to bypass any filters/options being called on `wp_insert_post`.
+			$update = $wpdb->update( $wpdb->posts, array( 'post_content' => stripslashes( $parsed_content ) ), array( 'ID' => $post->ID ) );
+
+			if ( ! $update ) {
+				WP_CLI::error( sprintf( "Error updating %d. Aborting. Updated %d posts so far.", $post->ID, $affected ) );
+				return;
+			}
+
+			$affected++;
+
+			if ( $affected % 100 == 0 ) {
+				WP_CLI::line( "100 posts updated. Waiting 1 second..." );
+				$this->stop_the_insanity();
+				sleep( 1 );
+			}
+
+		}
+
+		WP_CLI::success( sprintf( "Done! %d posts updated.", $affected ) );
+	}
 }
 
 WP_CLI::add_command( 'wpcom-compat', new WPCOM_Compat_Command );

--- a/class-wpcom-compat-command.php
+++ b/class-wpcom-compat-command.php
@@ -129,7 +129,7 @@ class WPCOM_Compat_Command extends WPCOM_VIP_CLI_Command {
 		$shortcode_tags = array();
 
 		// Add custom protected-iframe handler
-		add_shortcode( 'protected-iframe', function( $attrs ) use( $protected_embeds ) {
+		add_shortcode( 'protected-iframe', function ( $attrs ) use ( $protected_embeds ) {
 			return $protected_embeds[ $attrs['id'] ]['html'];
 		} );
 
@@ -137,7 +137,7 @@ class WPCOM_Compat_Command extends WPCOM_VIP_CLI_Command {
 		WP_CLI::line( 'Looking for posts with protected-iframe shortcode.' );
 
 		global $wpdb;
-		$query = $wpdb->get_results("SELECT ID, post_content FROM $wpdb->posts WHERE `post_content` LIKE '%protected-iframe%'" );
+		$query = $wpdb->get_results( "SELECT ID, post_content FROM $wpdb->posts WHERE `post_content` LIKE '%protected-iframe%'" );
 
 		$affected = 0;
 
@@ -145,7 +145,6 @@ class WPCOM_Compat_Command extends WPCOM_VIP_CLI_Command {
 		sleep( 3 );
 
 		foreach ( $query as $post ) {
-
 			// Post does not have a protected-iframe, skip it
 			if ( strpos( $post->post_content, 'protected-iframe' ) === false ) {
 				continue;
@@ -170,7 +169,6 @@ class WPCOM_Compat_Command extends WPCOM_VIP_CLI_Command {
 				$this->stop_the_insanity();
 				sleep( 1 );
 			}
-
 		}
 
 		WP_CLI::success( sprintf( 'Done! %d posts updated.', $affected ) );


### PR DESCRIPTION
This command will parse and render every single `protected-iframe` shortcode present on the site.

It requires a CSV file, that can be generated on the original site, with all the Protected Embeds. 