### PR TITLE
Adds the Writing Helper plugin

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,4 @@
+[submodule "plugins/writing-helper"]
+	path = plugins/writing-helper
+	url = https://github.com/Automattic/writing-helper.git
+	branch = master

--- a/README.md
+++ b/README.md
@@ -19,3 +19,7 @@ The following shortcodes are either ported over from WordPress.com or are create
 The following custom WP-CLI commands exist in this plugin:
 
 * `wpcom-compat import-protected-embeds` - Imports "protected embeds" from a CSV file into the database table `protected_embeds`.
+
+## Plugins
+
+* [Writing Helper](https://github.com/Automattic/writing-helper) - "Helps you write your posts."  This plugin is a feature on WordPress.com that allows posts to be copied and for feedback to be requested.  This plugin can be disabled by calling `add_filter( 'wpcom_compat_enable_writing_helper', '__return_false' );` before loading the WordPress.com Compatibility mu-plugin.

--- a/vip-go-wpcom-compat.php
+++ b/vip-go-wpcom-compat.php
@@ -9,3 +9,4 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 
 require_once __DIR__ . '/wpcom-deprecated-functions.php';
 require_once __DIR__ . '/wpcom-shortcodes.php';
+require_once __DIR__ . '/wpcom-plugins.php';

--- a/wpcom-plugins.php
+++ b/wpcom-plugins.php
@@ -1,0 +1,7 @@
+<?php
+
+// Enables the Writing Helper plugin that is a part of WordPress.com but not Jetpack.
+if ( true === apply_filters( 'wpcom_compat_enable_writing_helper', true ) && ! class_exists( 'Writing_Helper' ) ) {
+	require __DIR__ . '/plugins/writing-helper/writing-helper.php';
+}
+


### PR DESCRIPTION
The Writing Helper plugin is a feature of WordPress.com that is not a part of VIP Go, core WordPress, or Jetpack.

It can easily be disabled by calling `add_filter( 'wpcom_compat_enable_writing_helper', '__return_false' );` before loading the WordPress.com Compatibility mu-plugin.

Fixes Issue #9