### PR TITLE
Set WPCOM_VIP_USE_JETPACK_PHOTON on all migrated sites

### DIFF
--- a/vip-go-wpcom-compat.php
+++ b/vip-go-wpcom-compat.php
@@ -7,6 +7,9 @@ if ( defined( 'WP_CLI' ) && WP_CLI ) {
 	require_once __DIR__ . '/class-wpcom-compat-command.php';
 }
 
+// Dynamic rewrites for intermediate image sizes https://github.com/Automattic/vip-go-mu-plugins/pull/515
+define( 'WPCOM_VIP_USE_JETPACK_PHOTON', true );
+
 require_once __DIR__ . '/wpcom-deprecated-functions.php';
 require_once __DIR__ . '/wpcom-shortcodes.php';
 require_once __DIR__ . '/wpcom-hooks.php';


### PR DESCRIPTION
The WPCOM_VIP_USE_JETPACK_PHOTON is used to dynamically rewrite images for intermediate image URLs. This is needed for all sites moving from WordPress.com.