### PR TITLE
Add wpcom_vip_enable_https_canonical

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,7 @@ This plugin provides compatibility for sites that are moving from WordPress.com 
 The following functions are deprecated on VIP Go and are added as shims to keep themes and plugins from throwing fatal errors:
 
 * `wpcom_vip_load_wp_rest_api()` - Loads the built-in WP REST API endpoints in WordPress.com VIP context.  This function is not needed on VIP Go, or core WordPress to load the REST API and can be safely removed.
+* `wpcom_vip_enable_https_canonical()` - By default HTTP is forced to be the canonical version of URLs on WordPress.com. This function is not needed on VIP Go.
 
 ## Shortcodes
 

--- a/wpcom-deprecated-functions.php
+++ b/wpcom-deprecated-functions.php
@@ -9,3 +9,12 @@
 function wpcom_vip_load_wp_rest_api() {
 	_deprecated_function( __FUNCTION__, '2.0.0' );
 }
+
+/**
+ * By default HTTP is forced to be the cannonical version of URLs on WordPress.com.
+ *
+ * @deprecated Not applicable on VIP Go
+ */
+function wpcom_vip_enable_https_canonical() {
+	_deprecated_function( __FUNCTION__, '2.0.0' );
+}


### PR DESCRIPTION
This function is deprecated on VIP Go, but we need a placeholder to avoid fatals for migrated sites.