### PR TITLE
Deprecated: function require_lib( $slug )

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,7 @@ The following functions are deprecated on VIP Go and are added as shims to keep 
 
 * `wpcom_vip_load_wp_rest_api()` - Loads the built-in WP REST API endpoints in WordPress.com VIP context.  This function is not needed on VIP Go, or core WordPress to load the REST API and can be safely removed.
 * `wpcom_vip_enable_https_canonical()` - By default HTTP is forced to be the canonical version of URLs on WordPress.com. This function is not needed on VIP Go.
+* `require_lib( $slug )` - This internal WordPress.com function adds shared WordPress.com libraries. These libraries will need to be copied directly into the VIP Go client repository.
 
 ## Shortcodes
 

--- a/wpcom-deprecated-functions.php
+++ b/wpcom-deprecated-functions.php
@@ -30,4 +30,11 @@ function wpcom_vip_enable_https_canonical() {
  */
 function require_lib( $slug ) {
 	_deprecated_function( __FUNCTION__, '2.0.0' );
+	
+	// Attempt to offer minimal back-compat.
+	// If the lib happens to exist in client-mu-plugins/lib, load it.
+	$lib = WPCOM_VIP_CLIENT_MU_PLUGIN_DIR . '/lib/' . $slug . '/' . $slug . '.php';
+	if ( file_exists( $lib ) ) {
+		require_once( $lib );
+	}
 }

--- a/wpcom-deprecated-functions.php
+++ b/wpcom-deprecated-functions.php
@@ -18,3 +18,16 @@ function wpcom_vip_load_wp_rest_api() {
 function wpcom_vip_enable_https_canonical() {
 	_deprecated_function( __FUNCTION__, '2.0.0' );
 }
+
+/**
+ * Requires WordPress.com internal libraries
+ *
+ * This internal function is used in some WordPress.com themes. These shared libraries
+ * are no longer supported on VIP Go, so they will need to be copied directly into
+ * VIP Go client repositories as needed.
+ *
+ * @deprecated Not supported on VIP Go
+ */
+function require_lib( $slug ) {
+	_deprecated_function( __FUNCTION__, '2.0.0' );
+}


### PR DESCRIPTION
This  is an internal WordPress.com function that is not applicable on VIP Go. Any shared libraries will need to be copied into VIP Go client repositories as needed.