### PR TITLE
Proposal: Add support for WPCOM Geo Uniques

### DIFF
--- a/wpcom-deprecated-functions.php
+++ b/wpcom-deprecated-functions.php
@@ -38,3 +38,30 @@ function require_lib( $slug ) {
 		require_once( $lib );
 	}
 }
+
+/**
+ * @deprecated wpcom-geo-uniques has been re-implemented as vip-go-geo-uniques on VIP Go.
+ */
+function wpcom_geo_add_location( $location ) {
+	_deprecated_function( __FUNCTION__, '2.0.0' );
+	
+	return vip_geo_add_location( $location );
+}
+
+/**
+ * @deprecated wpcom-geo-uniques has been re-implemented as vip-go-geo-uniques on VIP Go.
+ */
+function wpcom_geo_get_user_location() {
+	_deprecated_function( __FUNCTION__, '2.0.0' );
+	
+	return vip_geo_get_country_code();
+}
+
+/**
+ * @deprecated wpcom-geo-uniques has been re-implemented as vip-go-geo-uniques on VIP Go.
+ */
+function wpcom_geo_set_default_location( $location ) {
+	_deprecated_function( __FUNCTION__, '2.0.0' );
+	
+	return vip_geo_set_default_location( $location );
+}


### PR DESCRIPTION
VIP Go Geo Uniques is our VIP Go port of the WPCOM Geo Uniques plugin. The function names are changed, but the arguments are the same. This will make it easier to copy VIP themes as-is from WordPress.com.

Keeping differences as minimal as possible while we're keeping the themes in sync across platforms will ease the migration process and then we can update the function names after everything is fully migrated.

Alternatively: We could search replace the function names in the migration process. In my opinion, deprecating the functions in this way is a cleaner approach, but I could see arguments against that as well.