### PR TITLE
Add is_wpcom_vip() to deprecated function file

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ The following functions are deprecated on VIP Go and are added as shims to keep 
 * `wpcom_vip_load_wp_rest_api()` - Loads the built-in WP REST API endpoints in WordPress.com VIP context.  This function is not needed on VIP Go, or core WordPress to load the REST API and can be safely removed.
 * `wpcom_vip_enable_https_canonical()` - By default HTTP is forced to be the canonical version of URLs on WordPress.com. This function is not needed on VIP Go.
 * `require_lib( $slug )` - This internal WordPress.com function adds shared WordPress.com libraries. These libraries will need to be copied directly into the VIP Go client repository.
+* `is_wpcom_vip()` - This checks if we are on a WordPress VIP platform vs local. Tihs function is not needed on VIP Go.
 
 ## Shortcodes
 

--- a/wpcom-deprecated-functions.php
+++ b/wpcom-deprecated-functions.php
@@ -72,3 +72,12 @@ function wpcom_vip_remove_bbpress2_staff_css() {
 function wpcom_vip_enabled_cap_in_oembed( $location = false ) {
 	_deprecated_function( __FUNCTION__, '2.0.0' );
 }
+
+/*
+ * @deprecated Not part of the VIP Go platform
+ */
+function is_wpcom_vip() {
+	_deprecated_function( __FUNCTION__, '2.0.0' );
+
+	return WPCOM_IS_VIP_ENV;
+}

--- a/wpcom-deprecated-functions.php
+++ b/wpcom-deprecated-functions.php
@@ -79,5 +79,5 @@ function wpcom_vip_enabled_cap_in_oembed( $location = false ) {
 function is_wpcom_vip() {
 	_deprecated_function( __FUNCTION__, '2.0.0' );
 
-	return WPCOM_IS_VIP_ENV;
+	return defined( 'WPCOM_IS_VIP_ENV' ) && true === WPCOM_IS_VIP_ENV ;
 }


### PR DESCRIPTION
https://vip-svn.wordpress.com/plugins/vip-do-not-include-on-wpcom/wpcom-vip-plugins-ui/wpcom-vip-plugins-ui.php

It's a function still being used above on WPCOM ^^ so if there is a check like `if ( ! function_exists( 'is_wpcom_vip' ) || ! is_wpcom_vip() )` it won't evaluate to `true` due to it not existing on VIP Go.