### PR TITLE
Fix: Undefined index: HTTP_HOST

### DIFF
--- a/wpcom-sitemap.php
+++ b/wpcom-sitemap.php
@@ -494,7 +494,7 @@ if ( ! function_exists( 'is_publicly_available' ) || is_publicly_available() ) {
 	add_action( 'deleted_post', __NAMESPACE__ . '\\sitemap_handle_update', 12, 1 );
 
 	$protocol = is_ssl() ? 'https://' : 'http://';
-	$request_url = $protocol . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'];
+	$request_url = isset( $_SERVER['HTTP_HOST'] ) ? $protocol . $_SERVER['HTTP_HOST'] . $_SERVER['REQUEST_URI'] : '';
 	if ( $request_url == home_url( 'sitemap.xml' ) ) {
 		add_action( 'init', __NAMESPACE__ . '\\wpcom_print_sitemap', 999 ); // run later so things like custom post types have been registered
 	} elseif ( $request_url == home_url( 'news-sitemap.xml' ) ) {


### PR DESCRIPTION
Fixes a PHP Notice when accessing the WP-CLI shell, since the `$_SERVER['HTTP_HOST']` key does not exist.

This can be seen on the wpvip.com site, and any others which pull in this vip-go-wpcom-compat plugin.