### PR TITLE
Use square brackets instead of curly bracket to retrieve string position

### DIFF
--- a/wpcom-hooks.php
+++ b/wpcom-hooks.php
@@ -65,7 +65,7 @@ function wpcom_make_content_clickable( $content ) {
 
 	foreach ( $split as $chunk ) {
 		// if $chunk is white space or a tag (or a combined tag), add it and continue.
-		if ( preg_match( '/^\s+$/', $chunk ) || ( '<' === $chunk{0} && '>' === $chunk{ strlen( $chunk ) - 1 } ) ) {
+		if ( preg_match( '/^\s+$/', $chunk ) || ( strpos( $chunk, '<' ) === 0 && '>' === $chunk[strlen( $chunk ) - 1] ) ) {
 			$out .= $chunk;
 			continue;
 		}


### PR DESCRIPTION
In PHP 7.4, using curly brackets to retrieve a string position is deprecated. 
Switch over to non deprecated usage of same functionality.

I receive the following error during extensive unit testing.
`Deprecated: Array and string offset access syntax with curly braces is deprecated in vip-go-wpcom-compat\wpcom-hooks.php on line 68`
