### PR TITLE
Fix: PHP 8.2 Compat

### DIFF
--- a/plugins/mrss.php
+++ b/plugins/mrss.php
@@ -114,7 +114,7 @@ if ( ! function_exists( 'mrss_init' ) ) {
 			$media['content']['attr']['medium'] = 'image';
 		}
 
-		$thumbnail = & get_post( $thumb_id );
+		$thumbnail = get_post( $thumb_id );
 		$title     = trim( strip_tags( $thumbnail->post_title ) );
 
 		if ( empty( $title ) ) {

--- a/plugins/mrss.php
+++ b/plugins/mrss.php
@@ -115,7 +115,7 @@ if ( ! function_exists( 'mrss_init' ) ) {
 		}
 
 		$thumbnail = get_post( $thumb_id );
-		$title     = trim( strip_tags( $thumbnail->post_title ) );
+		$title     = trim( strip_tags( $thumbnail->post_title ?? '' ) );
 
 		if ( empty( $title ) ) {
 			$title = trim( strip_tags( get_post_meta( $thumb_id, '_wp_attachment_image_alt', true ) ) );


### PR DESCRIPTION
This pull request addresses a compatibility issue with PHP 8.2 in the mrss_featured_image function. The PHP Notice "Only variables should be assigned by reference" was triggered due to the unnecessary use of the reference assignment operator &.

**Changes Made:**

Removed the `&` operator from the line `$thumbnail = & get_post( $thumb_id );`

In PHP 5 and later versions, objects are assigned by reference by default. The explicit reference assignment is thus redundant and can cause notices in PHP 8.2.
